### PR TITLE
Changes required by tracy 0.9.x that break compatibility with tracy 0…

### DIFF
--- a/godot_tracy/SCsub
+++ b/godot_tracy/SCsub
@@ -5,7 +5,7 @@ Import("env_modules")
 
 env_tracy = env_modules.Clone()
 
-tracy_dir = "./tracy/"
+tracy_dir = "./tracy/public/"
 
 tracy_src = [
     "TracyClient.cpp",

--- a/godot_tracy/profiler.h
+++ b/godot_tracy/profiler.h
@@ -1,4 +1,4 @@
 #ifndef GODOT_TRACY_PROFILER_H
 #define GODOT_TRACY_PROFILER_H
-#include "./tracy/Tracy.hpp"
+#include "./tracy/public/tracy/Tracy.hpp"
 #endif


### PR DESCRIPTION
Changes required by tracy 0.9.x that break compatibility with tracy 0.8.x. See: https://github.com/wolfpld/tracy/releases/tag/v0.9
